### PR TITLE
Use CLAMP instead of MIRROR

### DIFF
--- a/android/src/main/java/com/BV/LinearGradient/LinearGradientView.java
+++ b/android/src/main/java/com/BV/LinearGradient/LinearGradientView.java
@@ -90,7 +90,7 @@ public class LinearGradientView extends View {
             mEndPos[1] * mSize[1],
             mColors,
             mLocations,
-            Shader.TileMode.MIRROR);
+            Shader.TileMode.CLAMP);
         mPaint.setShader(mShader);
         invalidate();
     }


### PR DESCRIPTION
This matches the behavior on iOS where the gradient’s edge color is
extended if the view’s bounds exceed the gradient positions.