### PR TITLE
Update Readme With New Start/End Object Syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ props:
 
 ```javascript
 <LinearGradient
-  start={[0.0, 0.25]} end={[0.5, 1.0]}
+  start={{x: 0.0, y: 0.25}} end={{x: 0.5, y: 1.0}}
   locations={[0,0.5,0.6]}
   colors={['#4c669f', '#3b5998', '#192f6a']}
   style={styles.linearGradient}>


### PR DESCRIPTION
#129 changed the syntax for start/end but neglected to update the example in the readme.