### PR TITLE
Add index.js to save everyone fiddling with their eslint and/or flow configs

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,9 @@
+import { Platform } from "react-native";
+import LinearGradientIos from "./index.ios.js";
+import LinearGradientAndroid from "./index.android.js";
+
+const LinearGradient = Platform.OS === "ios"
+  ? LinearGradientIos
+  : LinearGradientAndroid;
+
+export default LinearGradient;


### PR DESCRIPTION
I can't see any harm doing this, but feel free to ignore if this causes any issues. Everything seems to work just fine on my end.

The alternative solution is to fix both eslint and flowconfig by tweaking their configs.

`.eslintrc`
```json
"settings": {
  "import/resolver": {
    "node": {
      "extensions": [".js", ".ios.js", ".android.js"]
    }
  }
}
```

`.flowconfig`
```
module.file_ext=.ios.js
module.file_ext=.android.js
module.file_ext=.js
module.file_ext=.jsx
module.file_ext=.json
```

Context: 
https://github.com/react-native-community/react-native-linear-gradient/issues/110
https://github.com/benmosher/eslint-plugin-import/issues/279