### PR TITLE
Handle Android RN 0.47 breaking change

### DIFF
--- a/android/src/main/java/com/BV/LinearGradient/LinearGradientPackage.java
+++ b/android/src/main/java/com/BV/LinearGradient/LinearGradientPackage.java
@@ -17,7 +17,7 @@ public class LinearGradientPackage implements ReactPackage {
         return Collections.emptyList();
     }
 
-    @Override
+    // Deprecated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8

Alternate proposal to #181. The advantage of this PR is that it's _not_ a breaking change. Users can continue to update `react-native-linear-gradient` without being forced to update RN to `>= 0.47`.

There is of course a down-side to this approach, `createJSModules()` is effectively dead code in `RN >= 0.47` and at some stage in the future someone has to remember to remove it. However, this is the approach I've taken with my own RN NPM packages.