### PR TITLE
Remove createJSModules @ovveride marker - RN 0.47 compatibility

### DIFF
--- a/android/src/main/java/com/BV/LinearGradient/LinearGradientPackage.java
+++ b/android/src/main/java/com/BV/LinearGradient/LinearGradientPackage.java
@@ -17,6 +17,7 @@ public class LinearGradientPackage implements ReactPackage {
         return Collections.emptyList();
     }
 
+    // Deprecated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }

--- a/android/src/main/java/com/BV/LinearGradient/LinearGradientPackage.java
+++ b/android/src/main/java/com/BV/LinearGradient/LinearGradientPackage.java
@@ -17,7 +17,6 @@ public class LinearGradientPackage implements ReactPackage {
         return Collections.emptyList();
     }
 
-    @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
[`createJSModules` is now not required on Android](https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8) from RN 0.47. I actually can't build an app on RN 0.47 without removing this method/@ovveride marker.