### PR TITLE
Fix Android compilation error with RN 0.47

### DIFF
--- a/android/src/main/java/com/BV/LinearGradient/LinearGradientPackage.java
+++ b/android/src/main/java/com/BV/LinearGradient/LinearGradientPackage.java
@@ -18,11 +18,6 @@ public class LinearGradientPackage implements ReactPackage {
     }
 
     @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-        return Collections.emptyList();
-    }
-
-    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return Arrays.<ViewManager>asList(
             new LinearGradientManager());


### PR DESCRIPTION
Method createJSModules was removed from RN 0.47. Which leads to compilation error due to @override annotation. This method can be removed right now (facebook/react-native#15232)