### PR TITLE
Moved to CGGradient to allow dithering (Closes #42)

### DIFF
--- a/BVLinearGradient.xcodeproj/project.pbxproj
+++ b/BVLinearGradient.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5B38DA701F69D72C00D9B28C /* BVLinearGradientLayer.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B38DA6F1F69D72C00D9B28C /* BVLinearGradientLayer.m */; };
+		5B38DA711F69D72C00D9B28C /* BVLinearGradientLayer.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B38DA6F1F69D72C00D9B28C /* BVLinearGradientLayer.m */; };
 		64AA15111EF7F31200718508 /* BVLinearGradient.m in Sources */ = {isa = PBXBuildFile; fileRef = EF6045ED1C4E5D290001F552 /* BVLinearGradient.m */; };
 		64AA15121EF7F31200718508 /* BVLinearGradientManager.m in Sources */ = {isa = PBXBuildFile; fileRef = EF6045EF1C4E5D290001F552 /* BVLinearGradientManager.m */; };
 		EF6045F01C4E5D290001F552 /* BVLinearGradient.m in Sources */ = {isa = PBXBuildFile; fileRef = EF6045ED1C4E5D290001F552 /* BVLinearGradient.m */; };
@@ -36,6 +38,8 @@
 
 /* Begin PBXFileReference section */
 		134814201AA4EA6300B7C361 /* libBVLinearGradient.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libBVLinearGradient.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		5B38DA6E1F69D72C00D9B28C /* BVLinearGradientLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BVLinearGradientLayer.h; sourceTree = "<group>"; };
+		5B38DA6F1F69D72C00D9B28C /* BVLinearGradientLayer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BVLinearGradientLayer.m; sourceTree = "<group>"; };
 		64AA15081EF7F30100718508 /* libBVLinearGradient.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libBVLinearGradient.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		EF6045EC1C4E5D290001F552 /* BVLinearGradient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BVLinearGradient.h; sourceTree = "<group>"; };
 		EF6045ED1C4E5D290001F552 /* BVLinearGradient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BVLinearGradient.m; sourceTree = "<group>"; };
@@ -83,6 +87,8 @@
 			children = (
 				EF6045EC1C4E5D290001F552 /* BVLinearGradient.h */,
 				EF6045ED1C4E5D290001F552 /* BVLinearGradient.m */,
+				5B38DA6E1F69D72C00D9B28C /* BVLinearGradientLayer.h */,
+				5B38DA6F1F69D72C00D9B28C /* BVLinearGradientLayer.m */,
 				EF6045EE1C4E5D290001F552 /* BVLinearGradientManager.h */,
 				EF6045EF1C4E5D290001F552 /* BVLinearGradientManager.m */,
 			);
@@ -169,6 +175,7 @@
 			files = (
 				EF6045F11C4E5D290001F552 /* BVLinearGradientManager.m in Sources */,
 				EF6045F01C4E5D290001F552 /* BVLinearGradient.m in Sources */,
+				5B38DA701F69D72C00D9B28C /* BVLinearGradientLayer.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -178,6 +185,7 @@
 			files = (
 				64AA15111EF7F31200718508 /* BVLinearGradient.m in Sources */,
 				64AA15121EF7F31200718508 /* BVLinearGradientManager.m in Sources */,
+				5B38DA711F69D72C00D9B28C /* BVLinearGradientLayer.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -356,6 +364,7 @@
 				64AA150F1EF7F30100718508 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/BVLinearGradient/BVLinearGradient.h
+++ b/BVLinearGradient/BVLinearGradient.h
@@ -3,4 +3,9 @@
 
 @interface BVLinearGradient : RCTView
 
+@property (nullable, nonatomic, strong) NSArray *colors;
+@property (nullable, nonatomic, strong) NSArray<NSNumber *> *locations;
+@property (nonatomic) CGPoint startPoint;
+@property (nonatomic) CGPoint endPoint;
+
 @end

--- a/BVLinearGradient/BVLinearGradient.m
+++ b/BVLinearGradient/BVLinearGradient.m
@@ -1,42 +1,65 @@
 #import "BVLinearGradient.h"
 #import <React/RCTConvert.h>
 #import <UIKit/UIKit.h>
-#import <QuartzCore/QuartzCore.h>
+#import "BVLinearGradientLayer.h"
 
 @implementation BVLinearGradient
 
 + (Class)layerClass
 {
-  return [CAGradientLayer class];
+    return [BVLinearGradientLayer class];
 }
 
-- (CAGradientLayer *)gradientLayer
+- (BVLinearGradientLayer *)gradientLayer
 {
-  return (CAGradientLayer *)self.layer;
+    return (BVLinearGradientLayer *)self.layer;
 }
 
 - (void)setColors:(NSArray *)colorStrings
 {
-  NSMutableArray *colors = [NSMutableArray arrayWithCapacity:colorStrings.count];
-  for (NSString *colorString in colorStrings) {
-    [colors addObject:(id)[RCTConvert UIColor:colorString].CGColor];
-  }
-  self.gradientLayer.colors = colors;
+    _colors = colorStrings;
+    
+    NSMutableArray *colors = [NSMutableArray arrayWithCapacity:colorStrings.count];
+    for (NSString *colorString in colorStrings)
+    {
+        if ([colorString isKindOfClass:UIColor.class])
+        {
+            [colors addObject:(UIColor *)colorString];
+        }
+        else
+        {
+            [colors addObject:(id)[RCTConvert UIColor:colorString].CGColor];
+        }
+    }
+    self.gradientLayer.colors = colors;
 }
 
 - (void)setStartPoint:(CGPoint)startPoint
 {
-  self.gradientLayer.startPoint = startPoint;
+    _startPoint = startPoint;
+    self.gradientLayer.startPoint = startPoint;
 }
 
 - (void)setEndPoint:(CGPoint)endPoint
 {
-  self.gradientLayer.endPoint = endPoint;
+    _endPoint = endPoint;
+    self.gradientLayer.endPoint = endPoint;
 }
 
 - (void)setLocations:(NSArray *)locations
 {
-  self.gradientLayer.locations = locations;
+    _locations = locations;
+    self.gradientLayer.locations = locations;
+}
+
+- (BOOL)respondsToSelector:(SEL)aSelector
+{
+    if (aSelector == @selector(displayLayer:))
+    {
+        return NO;
+    }
+    
+    return [super respondsToSelector:aSelector];
 }
 
 @end

--- a/BVLinearGradient/BVLinearGradientLayer.h
+++ b/BVLinearGradient/BVLinearGradientLayer.h
@@ -1,0 +1,12 @@
+#import <Foundation/Foundation.h>
+#import <QuartzCore/QuartzCore.h>
+
+@interface BVLinearGradientLayer : CALayer
+
+@property (nullable, nonatomic, strong) NSArray<UIColor *> *colors;
+@property (nullable, nonatomic, strong) NSArray<NSNumber *> *locations;
+@property (nonatomic) CGPoint startPoint;
+@property (nonatomic) CGPoint endPoint;
+
+
+@end

--- a/BVLinearGradient/BVLinearGradientLayer.m
+++ b/BVLinearGradient/BVLinearGradientLayer.m
@@ -1,0 +1,94 @@
+#import "BVLinearGradientLayer.h"
+
+@implementation BVLinearGradientLayer
+{
+    BOOL _needsNewGradient;
+    CGGradientRef _lastGradient;
+}
+
+- (instancetype)init
+{
+    self = [super init];
+    
+    if (self)
+    {
+        self.needsDisplayOnBoundsChange = YES;
+        _needsNewGradient = YES;
+    }
+    
+    return self;
+}
+
+- (void)setNeedsNewGradient
+{
+    _needsNewGradient = YES;
+    [self setNeedsDisplay];
+}
+
+- (void)setColors:(NSArray<UIColor *> *)colors
+{
+    _colors = colors;
+    [self setNeedsNewGradient];
+}
+
+- (void)setLocations:(NSArray<NSNumber *> *)locations
+{
+    _locations = locations;
+    [self setNeedsNewGradient];
+}
+
+- (void)setStartPoint:(CGPoint)startPoint
+{
+    _startPoint = startPoint;
+    [self setNeedsNewGradient];
+}
+
+- (void)setEndPoint:(CGPoint)endPoint
+{
+    _endPoint = endPoint;
+    [self setNeedsNewGradient];
+}
+
+- (void)drawInContext:(CGContextRef)ctx
+{
+    if (!_colors)
+        return;
+    
+    if (!_lastGradient || _needsNewGradient)
+    {
+        CGFloat *locations = nil;
+        
+        locations = malloc(sizeof(CGFloat) * _colors.count);
+        
+        for (NSInteger i = 0; i < _colors.count; i++)
+        {
+            if (_locations.count > i)
+            {
+                locations[i] = _locations[i].floatValue;
+            }
+            else
+            {
+                locations[i] = (1 / (_colors.count - 1)) * i;
+            }
+        }
+        
+        _lastGradient = CGGradientCreateWithColors(nil, (CFArrayRef)_colors, locations);
+        _needsNewGradient = NO;
+        
+        free(locations);
+    }
+    
+    CGSize size = self.bounds.size;
+    
+    if (size.width == 0.0 || size.height == 0.0)
+        return;
+    
+    CGPoint start = self.startPoint, end = self.endPoint;
+    
+    CGContextDrawLinearGradient(ctx, _lastGradient,
+                                CGPointMake(start.x * size.width, start.y * size.height),
+                                CGPointMake(end.x * size.width, end.y * size.height),
+                                kCGGradientDrawsBeforeStartLocation | kCGGradientDrawsAfterEndLocation);
+}
+
+@end


### PR DESCRIPTION
This will also allow radial gradients later.


I had to use an ObjC "hack" to avoid the default `displayLayer` code from `RCTView`. That's because ReactNative is **too opinionated** and does not provide any way to draw a `CALayer` in its default mode.
The only reason that `CAGradientLayer` worked without this is that Apple did some magic under the hood to cache a (very) low resolution `CGImage` and force it on `contents` property, probably through using a getter.
The thing is we can actually use the default caching mechanism, we do not need to create our own `CGImage` cache.

Anyway, gradients are beautiful now!

