### PR TITLE
Add react-native-web-linear-gradient in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,9 @@ Check out [Examples/AnimatedGradient](https://github.com/react-native-community/
 ### An example app
 You can see this component in action in [brentvatne/react-native-login](https://github.com/brentvatne/react-native-login/blob/master/App/Screens/LoginScreen.js#L58-L62).
 
+### Other platforms
+- Web: [react-native-web-community/react-native-web-linear-gradient](https://github.com/react-native-web-community/react-native-web-linear-gradient)
+
 ### License
 
 License is MIT


### PR DESCRIPTION
Hi,

I made an implementation of this package for RN Web at https://github.com/react-native-web-community/react-native-web-linear-gradient.
This is a PR to add a link to it in the README.
If you're willing to add web support directly to this library, please let me know, I'll be glad to add it! :)
