### PR TITLE
Check for ext property on Android gradle module

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,11 +10,13 @@ buildscript {
 
 apply plugin: 'com.android.library'
 
-def _reactNativeVersion = rootProject.ext.reactNative ?: '+';
-def _compileSdkVersion = rootProject.ext.compileSdkVersion ?: 26;
-def _buildToolsVersion = rootProject.ext.buildToolsVersion ?: '26.0.1';
-def _minSdkVersion = rootProject.ext.minSdkVersion ?: 16;
-def _targetSdkVersion = rootProject.ext.targetSdkVersion ?: 26;
+def _ext = rootProject.ext;
+
+def _reactNativeVersion = _ext.has('reactNative') ? _ext.reactNative : '+';
+def _compileSdkVersion = _ext.has('compileSdkVersion') ? _ext.compileSdkVersion : 26;
+def _buildToolsVersion = _ext.has('buildToolsVersion') ? _ext.buildToolsVersion : '26.0.1';
+def _minSdkVersion = _ext.has('minSdkVersion') ? _ext.minSdkVersion : 16;
+def _targetSdkVersion = _ext.has('targetSdkVersion') ? _ext.targetSdkVersion : 26;
 
 android {
     compileSdkVersion _compileSdkVersion


### PR DESCRIPTION
I did some tests and realize that the previous [commit (#163)](https://github.com/react-native-community/react-native-linear-gradient/pull/163/files#diff-7ae5a9093507568eabbf35c3b0665732R30) introduced a wrong behavior that was maintained in [#231](https://github.com/react-native-community/react-native-linear-gradient/pull/231/files#diff-7ae5a9093507568eabbf35c3b0665732R13)

What happens is that, when we use a statement (`project.ext.reactNative`) in our `.gradle` file, we are saying that we want to use the [ExtraPropertiesExtension](https://docs.gradle.org/current/dsl/org.gradle.api.plugins.ExtraPropertiesExtension.html) and get a property from this called `reactNative`, but if the property doesn't exist an error will be thrown.

The case where it works well is when we change the `project.ext` by `rootProject.ext` and start to check if any `ext`'s property exists before using it.