### PR TITLE
Package AAR file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ gradle/
 *.properties
 *.iml
 npm-debug.log
+android/repository

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ Version 2.0 supports react-native >= 0.40.0
 
 ## Add it to your project
 
+### iOS
+
 You can try linking the project automatically:
 
 `$ react-native link`
 
 or do it manually as described below:
-
-### iOS
 
 - Run `npm install react-native-linear-gradient --save`
 
@@ -57,24 +57,24 @@ Then:
 
 For instance the podspec file does not contain the right data (author attributes etc..) in npm while it does in the github repo.
 
-#### Android
+### Android
 
-1. in `android/settings.gradle`
+1. in `android/app/build.gradle` add:
 ```
-...
-include ':react-native-linear-gradient'
-project(':react-native-linear-gradient').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-linear-gradient/android')
-```
+repository {
+  ...
+  maven {
+    url "$rootDir/node-modules/react-native-linear-gradient/android/repository"
+  }
+}
 
-2. in `android/app/build.gradle` add:
-```
 dependencies {
     ...
-    compile project(':react-native-linear-gradient')
+    compile 'react-native-community:react-native-linear-gradient:+'
 }
 ```
 
-3. and finally, in `android/src/main/java/com/{YOUR_APP_NAME}/MainActivity.java` for react-native < 0.29,
+2. and finally, in `android/src/main/java/com/{YOUR_APP_NAME}/MainActivity.java` for react-native < 0.29,
    or `android/src/main/java/com/{YOUR_APP_NAME}/MainApplication.java` for react-native >= 0.29 add:
 ```java
 //...
@@ -131,13 +131,13 @@ In addition to regular `View` props, you can also provide additional props to cu
 
 #### colors
 An array of at least two color values that represent gradient colors. Example: `['red', 'blue']` sets gradient from red to blue.
-  
+
 #### start
 An optional object of the following type: `{ x: number, y: number }`. Coordinates declare the position that the gradient starts at, as a fraction of the overall size of the gradient, starting from the top left corner. Example: `{ x: 0.1, y: 0.1 }` means that the gradient will start 10% from the top and 10% from the left.
- 
+
 #### end
 Same as start, but for the end of the gradient.
- 
+
 #### locations
 An optional array of numbers defining the location of each gradient color stop, mapping to the color with the same index in `colors` prop. Example: `[0.1, 0.75, 1]` means that first color will take 0% - 10%, second color will take 10% - 75% and finally third color will occupy 75% - 100%.
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -33,6 +33,13 @@ android {
     }
 }
 
+repositories {
+    jcenter()
+    maven {
+        url "$rootDir/../node_modules/react-native/android"
+    }
+}
+
 dependencies {
     //noinspection GradleDynamicVersion
     provided "com.facebook.react:react-native:${_reactNativeVersion}"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,3 +1,5 @@
+import groovy.json.JsonSlurper
+
 buildscript {
     repositories {
         jcenter()
@@ -9,6 +11,7 @@ buildscript {
 }
 
 apply plugin: 'com.android.library'
+apply plugin: 'maven'
 
 def _ext = rootProject.ext;
 
@@ -43,4 +46,18 @@ repositories {
 dependencies {
     //noinspection GradleDynamicVersion
     provided "com.facebook.react:react-native:${_reactNativeVersion}"
+}
+
+task generateReactArchive(type: Upload) {
+    configuration = configurations.archives
+    def jsonFile = file("$rootDir/../package.json")
+    def packageJson = new JsonSlurper().parseText(jsonFile.text)
+    repositories.mavenDeployer {
+        repository url: "file://${rootDir}/repository"
+        pom.project {
+            groupId 'react-native-community'
+            artifactId 'react-native-linear-gradient'
+            version packageJson.version
+        }
+    }
 }

--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
   },
   "dependencies": {
     "prop-types": "^15.5.10"
+  },
+  "devDependencies": {
+    "react-native": "^0.51.0"
   }
 }


### PR DESCRIPTION
This PR introduces pre-packaging of the Android lib in as an AAR archive, as per #239.

This solves a bunch of problems with the current approach, as described in the issue (Android Studio failing to compile from time to time, different build tools version between client and library and compilation time).

I added a dev dependency to react-native, but the library is packaged with a `provide` directive so it won't include react-native in the artifact, it's still required to compile the library.

The lib version is parsed from `package.json` and to compile the lib you can invoke `./gradlew generateReactArchive`.

What's left to do is to include the artifact inside the published npm library, for which I don't know the process, happy to add more stuff if someone can point me in the right direction :)

The only doubt I had was with the `react-native link` command, but I tried and it seems like it won't add it to the project, so that should be fine. Ideally there would be a way to customise what link adds to the project on a per-library basis. This also means this PR implies `react-native link` won't work anymore for Android.