### PR TITLE
Configurable Android build Gradle plugin

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,8 +3,11 @@ buildscript {
         jcenter()
     }
 
+    def _androidBuildPluginVersion = rootProject.ext.has('androidBuildPluginVersion') ?
+            rootProject.ext.androidBuildPluginVersion : '2.3.3'
+            
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath "com.android.tools.build:gradle:${_androidBuildPluginVersion}"
     }
 }
 


### PR DESCRIPTION
Make the Android build Gradle plugin version configurable via the rootProject.ext map