### PR TITLE
Fix error "Tried to register two views with the same name BVLinearGradient"

### DIFF
--- a/index.android.js
+++ b/index.android.js
@@ -1,9 +1,11 @@
 // @flow
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { processColor, requireNativeComponent, PointPropType, StyleSheet, View, ViewPropTypes } from 'react-native';
+import { processColor, PointPropType, StyleSheet, View, ViewPropTypes } from 'react-native';
 import type { ViewProps } from 'react-native/Libraries/Components/View/ViewPropTypes';
 const deprecatedPropType = require('react-native/Libraries/Utilities/deprecatedPropType.js');
+
+import NativeLinearGradient from './nativeLinearGradient';
 
 const convertPoint = (name, point) => {
   if (Array.isArray(point)) {
@@ -100,5 +102,3 @@ export default class LinearGradient extends Component {
     );
   }
 }
-
-const NativeLinearGradient = requireNativeComponent('BVLinearGradient', null);

--- a/index.ios.js
+++ b/index.ios.js
@@ -4,9 +4,11 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { processColor, requireNativeComponent, PointPropType, View, ViewPropTypes } from 'react-native';
+import { processColor, PointPropType, View, ViewPropTypes } from 'react-native';
 import type { ViewProps } from 'react-native/Libraries/Components/View/ViewPropTypes';
 const deprecatedPropType = require('react-native/Libraries/Utilities/deprecatedPropType.js');
+
+import NativeLinearGradient from './nativeLinearGradient';
 
 const convertPoint = (name, point) => {
   if (Array.isArray(point)) {
@@ -81,5 +83,3 @@ export default class LinearGradient extends Component {
     );
   }
 }
-
-const NativeLinearGradient = requireNativeComponent('BVLinearGradient', null);

--- a/nativeLinearGradient.js
+++ b/nativeLinearGradient.js
@@ -1,0 +1,4 @@
+import { requireNativeComponent } from 'react-native';
+
+export default requireNativeComponent('BVLinearGradient', null);
+


### PR DESCRIPTION
React Native starting from version 0.49 triggers this error if you are trying to call requireNativeComponent() for the same component more than once. Even if they are called from different modules.