### PR TITLE
Rename start and end props to startPoint and endPoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,18 +132,18 @@ In addition to regular `View` props, you can also provide additional props to cu
 #### colors
 An array of at least two color values that represent gradient colors. Example: `['red', 'blue']` sets gradient from red to blue.
   
-#### start
+#### startPoint
 An optional object of the following type: `{ x: number, y: number }`. Coordinates declare the position that the gradient starts at, as a fraction of the overall size of the gradient, starting from the top left corner. Example: `{ x: 0.1, y: 0.1 }` means that the gradient will start 10% from the top and 10% from the left.
  
-#### end
-Same as start, but for the end of the gradient.
+#### endPoint
+Same as `startPoint`, but for the end of the gradient.
  
 #### locations
 An optional array of numbers defining the location of each gradient color stop, mapping to the color with the same index in `colors` prop. Example: `[0.1, 0.75, 1]` means that first color will take 0% - 10%, second color will take 10% - 75% and finally third color will occupy 75% - 100%.
 
 ```javascript
 <LinearGradient
-  start={{x: 0.0, y: 0.25}} end={{x: 0.5, y: 1.0}}
+  startPoint={{x: 0.0, y: 0.25}} endPoint={{x: 0.5, y: 1.0}}
   locations={[0,0.5,0.6]}
   colors={['#4c669f', '#3b5998', '#192f6a']}
   style={styles.linearGradient}>

--- a/index.android.js
+++ b/index.android.js
@@ -24,22 +24,22 @@ const convertPoint = (name, point) => {
 };
 
 type PropsType = {
-  start?: Array<number> | {x: number, y: number};
-  end?: Array<number> | {x: number, y: number};
+  startPoint?: Array<number> | {x: number, y: number};
+  endPoint?: Array<number> | {x: number, y: number};
   colors: Array<string>;
   locations?: Array<number>;
 } & ViewProps;
 
 export default class LinearGradient extends Component {
   static propTypes = {
-    start: PropTypes.oneOfType([
+    startPoint: PropTypes.oneOfType([
       PointPropType,
       deprecatedPropType(
         PropTypes.arrayOf(PropTypes.number),
         'Use point object with {x, y} instead.'
       )
     ]),
-    end: PropTypes.oneOfType([
+    endPoint: PropTypes.oneOfType([
       PointPropType,
       deprecatedPropType(
         PropTypes.arrayOf(PropTypes.number),
@@ -61,9 +61,9 @@ export default class LinearGradient extends Component {
     const {
       children,
       colors,
-      end,
+      endPoint,
       locations,
-      start,
+      startPoint,
       style,
       ...otherProps
     } = this.props;
@@ -95,8 +95,8 @@ export default class LinearGradient extends Component {
         <NativeLinearGradient
           style={{position: 'absolute', top: 0, left: 0, bottom: 0, right: 0}}
           colors={colors.map(processColor)}
-          startPoint={convertPoint('start', start)}
-          endPoint={convertPoint('end', end)}
+          startPoint={convertPoint('startPoint', startPoint)}
+          endPoint={convertPoint('endPoint', endPoint)}
           locations={locations ? locations.slice(0, colors.length) : null}
           borderRadii={borderRadiiPerCorner}
         />

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,8 +5,8 @@ declare module "react-native-linear-gradient" {
 
     export interface LinearGradientProps extends ReactNative.ViewProperties {
         colors: string[],
-        start?: { x: number, y: number },
-        end?: { x: number, y: number },
+        startPoint?: { x: number, y: number },
+        endPoint?: { x: number, y: number },
         locations?: number[]
     }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,14 +3,12 @@ import * as ReactNative from "react-native";
 
 declare module "react-native-linear-gradient" {
 
-    export interface LinearGradientProps extends ReactNative.ViewProperties {
+    export interface LinearGradientProps extends ReactNative.ViewProps {
         colors: string[],
         startPoint?: { x: number, y: number },
         endPoint?: { x: number, y: number },
         locations?: number[]
     }
 
-    export class LinearGradient extends React.Component<LinearGradientProps, any> { }
-
-    export default LinearGradient
+    export default class LinearGradient extends React.Component<LinearGradientProps, any> { }
 }

--- a/index.ios.js
+++ b/index.ios.js
@@ -26,22 +26,22 @@ const convertPoint = (name, point) => {
 };
 
 type PropsType = {
-  start?: Array<number> | {x: number, y: number};
-  end?: Array<number> | {x: number, y: number};
+  startPoint?: Array<number> | {x: number, y: number};
+  endPoint?: Array<number> | {x: number, y: number};
   colors: Array<string>;
   locations?: Array<number>;
 } & ViewProps;
 
 export default class LinearGradient extends Component {
   static propTypes = {
-    start: PropTypes.oneOfType([
+    startPoint: PropTypes.oneOfType([
       PointPropType,
       deprecatedPropType(
         PropTypes.arrayOf(PropTypes.number),
         'Use point object with {x, y} instead.'
       )
     ]),
-    end: PropTypes.oneOfType([
+    endPoint: PropTypes.oneOfType([
       PointPropType,
       deprecatedPropType(
         PropTypes.arrayOf(PropTypes.number),
@@ -61,8 +61,8 @@ export default class LinearGradient extends Component {
 
   render() {
     const {
-      start,
-      end,
+      startPoint,
+      endPoint,
       colors,
       locations,
       ...otherProps
@@ -75,8 +75,8 @@ export default class LinearGradient extends Component {
       <NativeLinearGradient
         ref={(component) => { this.gradientRef = component; }}
         {...otherProps}
-        startPoint={convertPoint('start', start)}
-        endPoint={convertPoint('end', end)}
+        startPoint={convertPoint('startPoint', startPoint)}
+        endPoint={convertPoint('endPoint', endPoint)}
         colors={colors.map(processColor)}
         locations={locations ? locations.slice(0, colors.length) : null}
       />


### PR DESCRIPTION
Continuation of #235.
Fix #279: Fix conflict with react native layout props

Current typescript typing has errors since this was merged: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/25083

~TODO: Make it backwards compatible~
TODO: Make a major bump release<!-- here and on expo -->