### PR TITLE
clean build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,18 +1,7 @@
-buildscript {
-    repositories {
-        jcenter()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
-    }
-}
-
 apply plugin: 'com.android.library'
 
 def _ext = rootProject.ext;
 
-def _reactNativeVersion = _ext.has('reactNative') ? _ext.reactNative : '+';
 def _compileSdkVersion = _ext.has('compileSdkVersion') ? _ext.compileSdkVersion : 26;
 def _buildToolsVersion = _ext.has('buildToolsVersion') ? _ext.buildToolsVersion : '26.0.1';
 def _minSdkVersion = _ext.has('minSdkVersion') ? _ext.minSdkVersion : 16;
@@ -35,5 +24,5 @@ android {
 
 dependencies {
     //noinspection GradleDynamicVersion
-    provided "com.facebook.react:react-native:${_reactNativeVersion}"
+    implementation "com.facebook.react:react-native:+"
 }


### PR DESCRIPTION
This change requires gradle plugin version 3.0 and up, and fixes gradle sync issues and warnings.

- remove gradle plugin specification, because we don't need it in the library, but root project. 
- use latest version of react-native as implementation dependency, which will speedup the build process

