### PR TITLE
Change implementation of gradient on iOS

### DIFF
--- a/BVLinearGradient.xcodeproj/project.pbxproj
+++ b/BVLinearGradient.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		64AA15111EF7F31200718508 /* BVLinearGradient.m in Sources */ = {isa = PBXBuildFile; fileRef = EF6045ED1C4E5D290001F552 /* BVLinearGradient.m */; };
 		64AA15121EF7F31200718508 /* BVLinearGradientManager.m in Sources */ = {isa = PBXBuildFile; fileRef = EF6045EF1C4E5D290001F552 /* BVLinearGradientManager.m */; };
+		D6BF2FA420D7DC1F006672AE /* BVLinearGradientLayer.m in Sources */ = {isa = PBXBuildFile; fileRef = D6BF2FA320D7DC1F006672AE /* BVLinearGradientLayer.m */; };
 		EF6045F01C4E5D290001F552 /* BVLinearGradient.m in Sources */ = {isa = PBXBuildFile; fileRef = EF6045ED1C4E5D290001F552 /* BVLinearGradient.m */; };
 		EF6045F11C4E5D290001F552 /* BVLinearGradientManager.m in Sources */ = {isa = PBXBuildFile; fileRef = EF6045EF1C4E5D290001F552 /* BVLinearGradientManager.m */; };
 /* End PBXBuildFile section */
@@ -37,6 +38,8 @@
 /* Begin PBXFileReference section */
 		134814201AA4EA6300B7C361 /* libBVLinearGradient.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libBVLinearGradient.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		64AA15081EF7F30100718508 /* libBVLinearGradient.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libBVLinearGradient.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		D6BF2FA220D7DC1F006672AE /* BVLinearGradientLayer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BVLinearGradientLayer.h; sourceTree = "<group>"; };
+		D6BF2FA320D7DC1F006672AE /* BVLinearGradientLayer.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BVLinearGradientLayer.m; sourceTree = "<group>"; };
 		EF6045EC1C4E5D290001F552 /* BVLinearGradient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BVLinearGradient.h; sourceTree = "<group>"; };
 		EF6045ED1C4E5D290001F552 /* BVLinearGradient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BVLinearGradient.m; sourceTree = "<group>"; };
 		EF6045EE1C4E5D290001F552 /* BVLinearGradientManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BVLinearGradientManager.h; sourceTree = "<group>"; };
@@ -85,6 +88,8 @@
 				EF6045ED1C4E5D290001F552 /* BVLinearGradient.m */,
 				EF6045EE1C4E5D290001F552 /* BVLinearGradientManager.h */,
 				EF6045EF1C4E5D290001F552 /* BVLinearGradientManager.m */,
+				D6BF2FA220D7DC1F006672AE /* BVLinearGradientLayer.h */,
+				D6BF2FA320D7DC1F006672AE /* BVLinearGradientLayer.m */,
 			);
 			path = BVLinearGradient;
 			sourceTree = "<group>";
@@ -169,6 +174,7 @@
 			files = (
 				EF6045F11C4E5D290001F552 /* BVLinearGradientManager.m in Sources */,
 				EF6045F01C4E5D290001F552 /* BVLinearGradient.m in Sources */,
+				D6BF2FA420D7DC1F006672AE /* BVLinearGradientLayer.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -356,6 +362,7 @@
 				64AA150F1EF7F30100718508 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/BVLinearGradient/BVLinearGradient.m
+++ b/BVLinearGradient/BVLinearGradient.m
@@ -1,27 +1,39 @@
 #import "BVLinearGradient.h"
+
+
 #import <React/RCTConvert.h>
 #import <UIKit/UIKit.h>
 #import <QuartzCore/QuartzCore.h>
+
+#import "BVLinearGradientLayer.h"
 
 @implementation BVLinearGradient
 
 + (Class)layerClass
 {
-  return [CAGradientLayer class];
+  return [BVLinearGradientLayer class];
 }
 
-- (CAGradientLayer *)gradientLayer
+- (BVLinearGradientLayer *)gradientLayer
 {
-  return (CAGradientLayer *)self.layer;
+  return (BVLinearGradientLayer *)self.layer;
 }
 
 - (void)setColors:(NSArray *)colorStrings
 {
-  NSMutableArray *colors = [NSMutableArray arrayWithCapacity:colorStrings.count];
-  for (NSString *colorString in colorStrings) {
-    [colors addObject:(id)[RCTConvert UIColor:colorString].CGColor];
-  }
-  self.gradientLayer.colors = colors;
+    NSMutableArray *colors = [NSMutableArray arrayWithCapacity:colorStrings.count];
+    for (NSString *colorString in colorStrings)
+    {
+        if ([colorString isKindOfClass:UIColor.class])
+        {
+            [colors addObject:(UIColor *)colorString];
+        }
+        else
+        {
+            [colors addObject:[RCTConvert UIColor:colorString]];
+        }
+    }
+    self.gradientLayer.colors = colors;
 }
 
 - (void)setStartPoint:(CGPoint)startPoint

--- a/BVLinearGradient/BVLinearGradientLayer.h
+++ b/BVLinearGradient/BVLinearGradientLayer.h
@@ -1,0 +1,10 @@
+#import <Foundation/Foundation.h>
+#import <QuartzCore/QuartzCore.h>
+
+@interface BVLinearGradientLayer : CALayer
+@property (nullable, nonatomic, copy) NSArray<UIColor *> *colors;
+@property (nullable, nonatomic, copy) NSArray<NSNumber *> *locations;
+@property (nonatomic) CGPoint startPoint;
+@property (nonatomic) CGPoint endPoint;
+@end
+

--- a/BVLinearGradient/BVLinearGradientLayer.m
+++ b/BVLinearGradient/BVLinearGradientLayer.m
@@ -1,0 +1,119 @@
+#import "BVLinearGradientLayer.h"
+
+#import <UIKit/UIKit.h>
+
+@implementation BVLinearGradientLayer
+
+- (instancetype)init
+{
+    self = [super init];
+
+    if (self)
+    {
+        self.needsDisplayOnBoundsChange = YES;
+        self.masksToBounds = YES;
+    }
+
+    return self;
+}
+
+- (void)setColors:(NSArray<id> *)colors
+{
+    _colors = colors;
+    [self setNeedsDisplay];
+}
+
+- (void)setLocations:(NSArray<NSNumber *> *)locations
+{
+    _locations = locations;
+    [self setNeedsDisplay];
+}
+
+- (void)setStartPoint:(CGPoint)startPoint
+{
+    _startPoint = startPoint;
+    [self setNeedsDisplay];
+}
+
+- (void)setEndPoint:(CGPoint)endPoint
+{
+    _endPoint = endPoint;
+    [self setNeedsDisplay];
+}
+
+- (void)display {
+    [super display];
+
+    if (self.contents) {
+        CGImageRelease((CGImageRef)self.contents);
+    }
+
+    BOOL hasAlpha = NO;
+
+    for (NSInteger i = 0; i < self.colors.count; i++) {
+        hasAlpha = hasAlpha || CGColorGetAlpha((__bridge CGColorRef)self.colors[i]) < 1.0;
+    }
+
+    UIGraphicsBeginImageContextWithOptions(self.bounds.size, !hasAlpha, 0.0);
+    CGContextRef ref = UIGraphicsGetCurrentContext();
+    [self drawInContext:ref];
+
+    UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
+    self.contents = (__bridge id _Nullable)(image.CGImage);
+    self.contentsScale = image.scale;
+
+    UIGraphicsEndImageContext();
+}
+
+- (void)drawInContext:(CGContextRef)ctx
+{
+    [super drawInContext:ctx];
+
+    CGContextSaveGState(ctx);
+
+    CGSize size = self.bounds.size;
+    if (!self.colors || self.colors.count == 0 || size.width == 0.0 || size.height == 0.0)
+        return;
+
+
+    CGFloat *locations = nil;
+
+    locations = malloc(sizeof(CGFloat) * self.colors.count);
+
+    for (NSInteger i = 0; i < self.colors.count; i++)
+    {
+        if (self.locations.count > i)
+        {
+            locations[i] = self.locations[i].floatValue;
+        }
+        else
+        {
+            locations[i] = (1.0 / (self.colors.count - 1)) * i;
+        }
+    }
+
+    CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
+    NSMutableArray *colors = [[NSMutableArray alloc] initWithCapacity:self.colors.count];
+    for (UIColor *color in self.colors) {
+        [colors addObject:(id)color.CGColor];
+    }
+
+    CGGradientRef gradient = CGGradientCreateWithColors(colorSpace, (CFArrayRef)colors, locations);
+
+    free(locations);
+
+    CGPoint start = self.startPoint, end = self.endPoint;
+
+
+
+    CGContextDrawLinearGradient(ctx, gradient,
+                                CGPointMake(start.x * size.width, start.y * size.height),
+                                CGPointMake(end.x * size.width, end.y * size.height),
+                                kCGGradientDrawsBeforeStartLocation | kCGGradientDrawsAfterEndLocation);
+    CGGradientRelease(gradient);
+    CGColorSpaceRelease(colorSpace);
+
+    CGContextRestoreGState(ctx);
+}
+
+@end


### PR DESCRIPTION
`CAGradientLayer` has numerous issues with accuracy of the produced
gradients for non-square views. This changes the implementation to a
custom layer with `CGContextDrawLinearGradient`. `drawInContext:` is not
implemented instead `display` is implemented which ensures that React
Native's custom code for rendering corner radii etc still works as
expected. However with some complex React Native view properties the
implementation will not work, but this is not a regression from the
`CAGradientLayer` implementation.

This is based on previous work done by
[danielgindi](https://github.com/danielgindi) in
https://github.com/react-native-community/react-native-linear-gradient/pull/215.