### PR TITLE
use ColorPropType instead of PropTypes.string for colors prop

### DIFF
--- a/index.android.js
+++ b/index.android.js
@@ -7,6 +7,7 @@ import PropTypes from 'prop-types';
 import { processColor, PointPropType, StyleSheet, View, ViewPropTypes } from 'react-native';
 import type { ViewProps } from 'react-native/Libraries/Components/View/ViewPropTypes';
 const deprecatedPropType = require('react-native/Libraries/Utilities/deprecatedPropType.js');
+const ColorPropType = require('react-native/Libraries/StyleSheet/ColorPropType.js');
 
 import NativeLinearGradient from './nativeLinearGradient';
 
@@ -46,7 +47,7 @@ export default class LinearGradient extends Component {
         'Use point object with {x, y} instead.'
       )
     ]),
-    colors: PropTypes.arrayOf(PropTypes.string).isRequired,
+    colors: PropTypes.arrayOf(ColorPropType).isRequired,
     locations: PropTypes.arrayOf(PropTypes.number),
     ...ViewPropTypes,
   };

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,7 +4,7 @@ import * as ReactNative from "react-native";
 declare module "react-native-linear-gradient" {
 
     export interface LinearGradientProps extends ReactNative.ViewProperties {
-        colors: string[],
+        colors: (string|number)[],
         start?: { x: number, y: number },
         end?: { x: number, y: number },
         locations?: number[]

--- a/index.ios.js
+++ b/index.ios.js
@@ -7,6 +7,7 @@ import PropTypes from 'prop-types';
 import { processColor, PointPropType, View, ViewPropTypes } from 'react-native';
 import type { ViewProps } from 'react-native/Libraries/Components/View/ViewPropTypes';
 const deprecatedPropType = require('react-native/Libraries/Utilities/deprecatedPropType.js');
+const ColorPropType = require('react-native/Libraries/StyleSheet/ColorPropType.js');
 
 import NativeLinearGradient from './nativeLinearGradient';
 
@@ -48,7 +49,7 @@ export default class LinearGradient extends Component {
         'Use point object with {x, y} instead.'
       )
     ]),
-    colors: PropTypes.arrayOf(PropTypes.string).isRequired,
+    colors: PropTypes.arrayOf(ColorPropType).isRequired,
     locations: PropTypes.arrayOf(PropTypes.number),
     ...ViewPropTypes,
   };


### PR DESCRIPTION
We have a function that looks like the following.

```
const opacity = function(color: any, opacityValue: number) {
  return setNormalizedColorAlpha(normalizeColor(color), opacityValue);
};
```

Using this function with `<LinearGradient />`  results in an error because the color returned is not a string but it is a valid color. I changed the component to use ColorPropType instead of accepting strings. Please let me know what else if anything is needed to get this merged. Cheers!