### PR TITLE
update typescript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,10 @@ declare module "react-native-linear-gradient" {
     import * as React from "react";
     import * as ReactNative from "react-native";
 
-    export type LinearGradientProps = Pick<ReactNative.ViewProps, Exclude<keyof ReactNative.ViewProps, 'start' | 'end'>> & {
+    type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+    type ReactNativeViewProps = Omit<ReactNative.ViewProps, 'start' | 'end'>;
+    
+    export interface LinearGradientProps extends ReactNativeViewProps {
         colors: (string|number)[],
         start?: { x: number, y: number },
         end?: { x: number, y: number },

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@ import * as ReactNative from "react-native";
 
 declare module "react-native-linear-gradient" {
 
-    export type LinearGradientProps = Exclude<ReactNative.ViewProperties, 'start' | 'end'> & {
+    export type LinearGradientProps = Exclude<ReactNative.ViewProps, 'start' | 'end'> & {
         colors: (string|number)[],
         start?: { x: number, y: number },
         end?: { x: number, y: number },

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,6 @@
-import * as React from "react";
-import * as ReactNative from "react-native";
-
 declare module "react-native-linear-gradient" {
+    import * as React from "react";
+    import * as ReactNative from "react-native";
 
     export type LinearGradientProps = Pick<ReactNative.ViewProps, Exclude<keyof ReactNative.ViewProps, 'start' | 'end'>> & {
         colors: (string|number)[],

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@ import * as ReactNative from "react-native";
 
 declare module "react-native-linear-gradient" {
 
-    export type LinearGradientProps = Exclude<ReactNative.ViewProps, 'start' | 'end'> & {
+    export type LinearGradientProps = Pick<ReactNative.ViewProps, Exclude<keyof ReactNative.ViewProps, 'start' | 'end'>> & {
         colors: (string|number)[],
         start?: { x: number, y: number },
         end?: { x: number, y: number },

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@ import * as ReactNative from "react-native";
 
 declare module "react-native-linear-gradient" {
 
-    export interface LinearGradientProps extends ReactNative.ViewProperties {
+    export type LinearGradientProps = Exclude<ReactNative.ViewProperties, 'start' | 'end'> & {
         colors: (string|number)[],
         start?: { x: number, y: number },
         end?: { x: number, y: number },


### PR DESCRIPTION
this would be a nice stop-gap until something like https://github.com/react-native-community/react-native-linear-gradient/pull/280 is merged

`ReactNative.ViewProps` has

```ts
{
  start?: number | string;
  end?: number | string;
}
```

[via `FlexStyle`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react-native/index.d.ts#L568)

but this component requires start/end to be Points. I've excluded the `start`/`end` from `ViewProps` in the Prop type to fix this