### PR TITLE
Fix default iOS direction

### DIFF
--- a/BVLinearGradient/BVLinearGradientLayer.m
+++ b/BVLinearGradient/BVLinearGradientLayer.m
@@ -12,6 +12,8 @@
     {
         self.needsDisplayOnBoundsChange = YES;
         self.masksToBounds = YES;
+        _startPoint = CGPointMake(0.5, 0.0);
+        _endPoint = CGPointMake(0.5, 1.0);
     }
 
     return self;

--- a/index.android.js
+++ b/index.android.js
@@ -54,6 +54,11 @@ export default class LinearGradient extends Component {
   props: PropsType;
   gradientRef: any;
 
+  static defaultProps = {
+    start: { x: 0.5, y: 0.0 },
+    end: { x: 0.5, y: 1.0 },
+  };
+
   setNativeProps(props: PropsType) {
     this.gradientRef.setNativeProps(props);
   }

--- a/index.ios.js
+++ b/index.ios.js
@@ -56,6 +56,11 @@ export default class LinearGradient extends Component {
   props: PropsType;
   gradientRef: any;
 
+  static defaultProps = {
+    start: { x: 0.5, y: 0.0 },
+    end: { x: 0.5, y: 1.0 },
+  };
+
   setNativeProps(props: PropsType) {
     this.gradientRef.setNativeProps(props);
   }


### PR DESCRIPTION
When moving from CAGradientLayer the default direction on iOS(vertical)
regressed because it was baked into CAGradientLayer, this fixes that.

@sibelius I think it might be better for future proofing to keep the defaults in Javascript rather than relying on them being done on the native side