### PR TITLE
Update obsolete provided to compileOnly

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,5 +35,5 @@ android {
 
 dependencies {
     //noinspection GradleDynamicVersion
-    provided "com.facebook.react:react-native:${_reactNativeVersion}"
+    compileOnly "com.facebook.react:react-native:${_reactNativeVersion}"
 }


### PR DESCRIPTION


Hi, as React native 0.56.0 is released with MAJOR android changes such as:

-Gradle 3.5.1
-Compile using Android SDK 26
-Google Maven repo
-etc

more about Change log, specially of Android Here, https://github.com/react-native-community/react-native-releases/blob/master/CHANGELOG.md#android-projects-are-now-compiled-using-the-android-26-sdk
and https://github.com/react-native-community/react-native-releases/blob/master/CHANGELOG.md#android-specific-changes

Aslo as Per Google new "**Google Play's target API level requirement**", mentioned here  https://developer.android.com/distribute/best-practices/develop/target-sdk



> Google Play will require that new apps target at least Android 8.0 (API level 26) from August 1, 2018, and that app updates target Android 8.0 from November 1, 2018.



It's clear that Android would be moving to new Gradle and new SDK changes, Thus creating a new type of error that is:

"**Configuration 'compile' is obsolete and has been replaced with 'implementation' or 'Api**'" 

more about the Old and new configuration please see this https://developer.android.com/studio/build/gradle-plugin-3-0-0-migration?utm_source=android-studio#new_configurations 
at the heading of "**_Use the new dependency configurations_**"

Therefore, all old "compile" should be now "implementation" or "provided" should be "compileOnly"

I have tested the with "compile" and "implementation" in my current release ready product and also by "renaming" "compile" to "implementation".

```
ext {
    buildToolsVersion = "26.0.3"
    minSdkVersion = 16
    compileSdkVersion = 26
    targetSdkVersion = 26
    supportLibVersion = "26.1.0"
}
```
Also tested with higher andorid SDK configs such as of below:

```
ext {
    buildToolsVersion = "27.0.3"
    minSdkVersion = 19
    compileSdkVersion = 27
    targetSdkVersion = 27
    supportLibVersion = "27.1.1"
}
```

so SDK 27 was also compiled successully. test on Android phone with ADK 23 all looks good. Thus, `react-native-linear-gradient` was working just fine as intended. thank you so much for this package.

Therefore, Please would it be possible to merge as i am sure many new projects and old one are going to update specially Gradle and SDK as of Google new requirements. 

related mention of Upgrading issue mention here https://github.com/facebook/react-native/issues/20273#issuecomment-405959030


Moreover, if someone still have any issue after upgrading everything successfully, then he should use following in build.gradle under `andorid/build.gradle`

```

subprojects {
    afterEvaluate {project ->
        if (project.hasProperty("android")) {
            android {
                compileSdkVersion 27
                buildToolsVersion '27.0.3'
                supportLibVersion = "27.1.1"
            }
        }
    }
}
```