### PR TITLE
Fix crash due to redundant free

### DIFF
--- a/BVLinearGradient/BVLinearGradientLayer.m
+++ b/BVLinearGradient/BVLinearGradientLayer.m
@@ -46,10 +46,6 @@
 - (void)display {
     [super display];
 
-    if (self.contents) {
-        CGImageRelease((CGImageRef)self.contents);
-    }
-
     BOOL hasAlpha = NO;
 
     for (NSInteger i = 0; i < self.colors.count; i++) {


### PR DESCRIPTION
`self.contents` is `strong` in `CALayer` and thus does not need to be
explicitly freed. If you end up actually freeing the image while the layer still uses it this results in a crash instead. 

Here's a quick gif to show it does not leak with this removed

![](https://media.giphy.com/media/nqpLZ5WYuNfsdNAprG/giphy.gif)

cc @sibelius 