### PR TITLE
[iOS] fix cocoa pods build

### DIFF
--- a/BVLinearGradient.podspec
+++ b/BVLinearGradient.podspec
@@ -13,7 +13,6 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = '9.0'
   s.source          = { :git => "https://github.com/brentvatne/react-native-linear-gradient.git", :tag => "#{s.version}" }
   s.source_files    = 'BVLinearGradient/*.{h,m}'
-  s.preserve_paths  = "**/*.js"
   s.frameworks = 'UIKit', 'QuartzCore', 'Foundation'
 
   s.dependency 'React'


### PR DESCRIPTION
Cf. this issue #271, I saw that most solutions did in fact involve not using CocoaPods. By removing `s.preserve_paths` in the `.podspec`, I managed to get the lib working with CocoaPods as well.