### PR TITLE
Ignore the images/ folder from the npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -11,3 +11,4 @@ gradle/
 *.iml
 npm-debug.log
 Examples/
+images/


### PR DESCRIPTION
before, unpacked size: 956.0 kB
after, unpacked size: 37.9 kB

(checked with `npm pack`)