### PR TITLE
Fix TypeScript error in types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@ declare module 'react-native-linear-gradient' {
   import * as React from 'react';
   import * as ReactNative from 'react-native';
 
-  export interface LinearGradientProps extends ReactNative.ViewProperties {
+  export interface LinearGradientProps extends ReactNative.ViewProps {
     colors: (string | number)[];
     start?: { x: number; y: number };
     end?: { x: number; y: number };

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,15 +1,15 @@
-declare module "react-native-linear-gradient" {
-    import * as React from "react";
-    import * as ReactNative from "react-native";
+declare module 'react-native-linear-gradient' {
+  import * as React from 'react';
+  import * as ReactNative from 'react-native';
 
-    export interface LinearGradientProps extends ReactNative.ViewProperties {
-        colors: (string|number)[],
-        start?: { x: number, y: number },
-        end?: { x: number, y: number },
-        locations?: number[]
-    }
+  export interface LinearGradientProps extends ReactNative.ViewProperties {
+    colors: (string | number)[];
+    start?: { x: number; y: number };
+    end?: { x: number; y: number };
+    locations?: number[];
+  }
 
-    export class LinearGradient extends React.Component<LinearGradientProps, any> { }
+  export class LinearGradient extends React.Component<LinearGradientProps, any> {}
 
-    export default LinearGradient
+  export default LinearGradient;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,6 @@
-import * as React from "react";
-import * as ReactNative from "react-native";
-
 declare module "react-native-linear-gradient" {
+    import * as React from "react";
+    import * as ReactNative from "react-native";
 
     export interface LinearGradientProps extends ReactNative.ViewProperties {
         colors: (string|number)[],

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,7 +9,7 @@ declare module 'react-native-linear-gradient' {
     locations?: number[];
   }
 
-  export class LinearGradient extends React.Component<LinearGradientProps, any> {}
+  export class LinearGradient extends React.Component<LinearGradientProps> {}
 
   export default LinearGradient;
 }


### PR DESCRIPTION
Here is the error with old version
![image](https://user-images.githubusercontent.com/12229968/47007844-c7cd4c80-d141-11e8-857c-a72819d2a554.png)

To fix this the imports have to be inside of the declared module.

Other things I did:
- format the code
- remove `any` state since this component doesn't have state
- Replace deprecated `ViewProperties` with `ViewProps`

There you go <3