### PR TITLE
fix(docs): gradle compile config depreciation

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ project(':react-native-linear-gradient').projectDir = new File(rootProject.proje
 ```
 dependencies {
     ...
-    compile project(':react-native-linear-gradient')
+    implementation project(':react-native-linear-gradient')
 }
 ```
 


### PR DESCRIPTION
PR facebook/react-native#20767 bumped the version of the Android
Gradle Plugin to v3 which uses the newer Gradle dependency
configurations `implementation` and `api` which make `compile`
obsolete.

PR facebook/react-native#20853 covered the `link` command.

Using `compile` will result in a warning message during app build and
`compile` will be eventually removed by Gradle.