### PR TITLE
Fix TS typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,6 +10,6 @@ declare module 'react-native-linear-gradient' {
   }
 
   export class LinearGradient extends React.Component<LinearGradientProps> {}
-
-  export default LinearGradient;
 }
+
+export default LinearGradient;


### PR DESCRIPTION
Fixes error:
```
node_modules/react-native-linear-gradient/index.d.ts:15:5 - error TS2666: Exports and export assignments are not permitted in module augmentations.
```