### PR TITLE
Remove React import for CocoaPods

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ Then either:
 add the following line to your Podfile:
 
 ```sh
-pod 'React', :path => '../node_modules/react-native'
 pod 'BVLinearGradient', :path => '../node_modules/react-native-linear-gradient'
 ```
 


### PR DESCRIPTION
Getting React from CocoaPods has been deprecated, adding the line to the Podfile causes the app to crash.