### PR TITLE
Update tag in podspec file due to new tag (v2.x.x) namings

### DIFF
--- a/BVLinearGradient.podspec
+++ b/BVLinearGradient.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.author          = { "Brent Vatne" => "brentvatne@gmail.com" }
   s.ios.deployment_target = '7.0'
   s.tvos.deployment_target = '9.0'
-  s.source          = { :git => "https://github.com/brentvatne/react-native-linear-gradient.git", :tag => "#{s.version}" }
+  s.source          = { :git => "https://github.com/brentvatne/react-native-linear-gradient.git", :tag => "v#{s.version}" }
   s.source_files    = 'BVLinearGradient/*.{h,m}'
   s.preserve_paths  = "**/*.js"
   s.frameworks = 'UIKit', 'QuartzCore', 'Foundation'


### PR DESCRIPTION
Using **react-native-linear-gradient** with pods causes error

Podfile:
```
pod 'BVLinearGradient', :podspec => '../node_modules/react-native-linear-gradient/BVLinearGradient.podspec'
```

```
pod install
```

```
[!] Error installing BVLinearGradient
[!] /usr/bin/git clone https://github.com/brentvatne/react-native-linear-gradient.git /var/folders/09/mkn71twx2833d_jgfsx0mryh0000gn/T/d20181203-73591-50p7uq --template= --single-branch --depth 1 --branch 2.5.2

Cloning into '/var/folders/09/mkn71twx2833d_jgfsx0mryh0000gn/T/d20181203-73591-50p7uq'...
warning: Could not find remote branch 2.5.2 to clone.
fatal: Remote branch 2.5.2 not found in upstream origin
```

because tag 2.5.2 can not be found as it does not exist.