### PR TITLE
Updated gradle version to 3.1.2

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,3 +1,16 @@
+buildscript {
+    repositories {
+        google()
+        jcenter()
+        maven {
+            url 'https://maven.fabric.io/public'
+        }
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:3.1.2'
+    }
+}
+
 apply plugin: 'com.android.library'
 
 def DEFAULT_COMPILE_SDK_VERSION             = 26


### PR DESCRIPTION
Could not find com.android.tools:common:25.3.3 fix
See Issue#375 on https://github.com/react-native-community/react-native-linear-gradient/issues/375