### PR TITLE
'compile' is obsolete

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ project(':react-native-linear-gradient').projectDir = new File(rootProject.proje
 ```
 dependencies {
     ...
-    compile project(':react-native-linear-gradient')
+    implementation project(':react-native-linear-gradient')
 }
 ```
 


### PR DESCRIPTION
According to Android Studio blog: 
Configuration 'compile' is obsolete and has been replaced with 'implementation'.
It will be removed at the end of 2018

People were getting error because of this.