### PR TITLE
Fix flow definition for LG Props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ChangeLog
 
+## 2.5.4 - 2019-02-20
+
+- Fix flow definition for LinearGradient prop types
+
 ## 2.5.3 - 2018-12-03
 
 - Fix angled gradient on Android

--- a/common.js
+++ b/common.js
@@ -5,7 +5,7 @@ import { requireNativeComponent, View } from 'react-native';
 export default requireNativeComponent('BVLinearGradient', null);
 
 export type Point = $Exact<{x: number, y: number}>;
-export type Props = $Exact<{
+type LinearGradientProps = {
   start?: Point;
   end?: Point;
   colors: string[];
@@ -13,4 +13,8 @@ export type Props = $Exact<{
   useAngle?: boolean;
   angleCenter?: Point;
   angle?: number;
-}> & typeof(View);
+};
+
+type ViewProps = typeof(View);
+
+export type Props = {| ...LinearGradientProps, ...ViewProps |}


### PR DESCRIPTION
Fix for the issue raised: https://github.com/react-native-community/react-native-linear-gradient/issues/385


Separated out the Linear Gradient Prop types and the View Prop types, there can be side effects doing an intersection on exact objects, the docs recommend to use the object type spread. So I've implemented this and the error has been removed. 
