### PR TITLE
podspec target ios 9.0

### DIFF
--- a/BVLinearGradient.podspec
+++ b/BVLinearGradient.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.summary         = "A <LinearGradient /> component for react-native"
   s.license         = "MIT"
   s.author          = { "Brent Vatne" => "brentvatne@gmail.com" }
-  s.ios.deployment_target = '7.0'
+  s.ios.deployment_target = '9.0'
   s.tvos.deployment_target = '9.0'
   s.source          = { :git => "https://github.com/brentvatne/react-native-linear-gradient.git", :tag => "v#{s.version}" }
   s.source_files    = 'BVLinearGradient/*.{h,m}'


### PR DESCRIPTION
# Summary

Xcode show warning that it's targeting 7.0 or below supported version (8.0). And React Native supports iOS 9.0 above, so it's reasonable to bump target iOS to 9.0.

## Test Plan

Xcode warning will go away.

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
