### PR TITLE
Adjust AnimatedGradient path on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,18 +223,18 @@ An optional array of numbers defining the location of each gradient color stop, 
 
 #### useAngle / angle / angleCenter
 
-You may want to achieve an angled gradient effect, similar to those in image editors like Photoshop.  
+You may want to achieve an angled gradient effect, similar to those in image editors like Photoshop.
 One issue is that you have to calculate the angle based on the view's size, which only happens asynchronously and will cause unwanted flickr.
 
 In order to do that correctly you can set `{ useAngle: true, angle: 45, angleCenter: { x: 0.5, y: 0.5} }`, to achieve a gradient with a 45 degrees angle, with its center positioned in the view's exact center.
 
-`useAngle` is used to turn on/off angle based calculation (as opposed to `start`/`end`).  
-`angle` is the angle in degrees.  
+`useAngle` is used to turn on/off angle based calculation (as opposed to `start`/`end`).
+`angle` is the angle in degrees.
 `angleCenter` is the center point of the angle (will control the weight and stretch of the gradient like it does in photoshop.
 
 ### Updating the values for fun
 
-Check out [Examples/AnimatedGradient](https://github.com/react-native-community/react-native-linear-gradient/blob/master/Examples/AnimatedGradient/src/index.js) (`git clone` this project, cd into it, npm install, open in Xcode and run) to see how this is done:
+Check out [Examples/AnimatedGradient](https://github.com/react-native-community/react-native-linear-gradient/blob/master/Examples/AnimatedGradient/index.js) (`git clone` this project, cd into it, npm install, open in Xcode and run) to see how this is done:
 
 ![Example with extra props](https://raw.githubusercontent.com/react-native-community/react-native-linear-gradient/master/images/example-animated.gif)
 


### PR DESCRIPTION
This PR fixes a link pointing to `Example/AnimatedGradient` on README.md.