### PR TITLE
Update Android Gradle plugin to 3.5.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,16 +3,16 @@ def safeExtGet(prop, fallback) {
 }
 
 buildscript {
-    repositories {
-        google()
-        jcenter()
-    }
     // The Android Gradle plugin is only required when opening the android folder stand-alone.
     // This avoids unnecessary downloads and potential conflicts when the library is included as a
     // module dependency in an application project.
     if (project == rootProject) {
+        repositories {
+            google()
+            jcenter()
+        }
         dependencies {
-            classpath 'com.android.tools.build:gradle:3.5.0'
+            classpath 'com.android.tools.build:gradle:3.5.1'
         }
     }
 }


### PR DESCRIPTION
Quick update to the latest version of the Android Gradle plugin

https://androidstudio.googleblog.com/2019/10/android-studio-351-available.html

Note that this _only_ affects building the library standalone (on a developer's machine). It does not affect any app projects using this library.