### PR TITLE
Update Android Gradle plugin to 3.5.2

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,16 +3,16 @@ def safeExtGet(prop, fallback) {
 }
 
 buildscript {
-    // The Android Gradle plugin is only required when opening the android folder stand-alone.
-    // This avoids unnecessary downloads and potential conflicts when the library is included as a
-    // module dependency in an application project.
     if (project == rootProject) {
+        // The Android Gradle plugin is only required when opening the android folder stand-alone.
+        // This avoids unnecessary downloads and potential conflicts when the library is included as a
+        // module dependency in an application project.
         repositories {
             google()
             jcenter()
         }
         dependencies {
-            classpath 'com.android.tools.build:gradle:3.5.1'
+            classpath 'com.android.tools.build:gradle:3.5.2'
         }
     }
 }


### PR DESCRIPTION
[Android Studio 3.5.2 is now available in the Stable channel](https://androidstudio.googleblog.com/2019/11/android-studio-352-available.html).

The Android Gradle plugin has been updated to `3.5.2` as well.