### PR TITLE
Add transparent color example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,20 @@ On iOS you can use the `MaskedViewIOS` to display text with a gradient. The tric
 </MaskedViewIOS>
 ```
 
+### Transparent Gradient
+
+The use of `transparent` color will most likely not lead to the expected result. `transparent` is actually a transparent black color (`rgba(0, 0, 0, 0)`). If you need a gradient in which the color is "fading", you need to have the same color with changing alpha channel. Example:
+
+```jsx
+// RGBA
+
+<LinearGradient colors={['rgba(255, 255, 255, 0)', 'rgba(255, 255, 255, 1)']} {...otherGradientProps} />
+
+// Hex
+
+<LinearGradient colors={['#FFFFFF00', '#FFFFFF']} {...otherGradientProps} />
+```
+
 ### Additional props
 
 In addition to regular `View` props, you can also provide additional props to customize your gradient look:


### PR DESCRIPTION
Linear gradient with a fading effect (using transparent color) is a common use case. For example, it's often used at the bottom of long scroll views to show there is more content below.

Developers usually pass the `transparent` color in `colors` array, but often it doesn't lead to the expected result as `transparent` is actually a black color with `0` alpha. There are a few issues related to this: #2 #36 #104 #322 #358 

I've added an example with transparent LinearGradient to the README

Related to: #360 