### PR TITLE
Update React dependency in podspec

### DIFF
--- a/BVLinearGradient.podspec
+++ b/BVLinearGradient.podspec
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
   s.preserve_paths  = "**/*.js"
   s.frameworks = 'UIKit', 'QuartzCore', 'Foundation'
 
-  s.dependency 'React'
+  s.dependency 'React-Core'
 
 end


### PR DESCRIPTION
According to [this thread](https://github.com/facebook/react-native/issues/29633), changing `React` to `React-Core` in the podspec file is a requirement for building with Xcode 12. More info in this comment by @alloy: https://github.com/facebook/react-native/issues/29633#issuecomment-694187116.

EDIT: Closes #501 (duplicate)