### PR TITLE
Update CI Node.js test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ['12', '14', '16']
+        node: ['14', '16', '18']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2


### PR DESCRIPTION
Add Node.js 18, remove Node.js 12.

With this, we include the two LTS versions, as well as "current".
Version 12 has been marked end-of-life in April 2022.