### PR TITLE
Fix: style layout native incorrect new architecture 

### DIFF
--- a/index.android.js
+++ b/index.android.js
@@ -2,9 +2,8 @@
  * @providesModule LinearGradient
  * @flow
  */
-import React, { Component, createRef } from 'react';
-import { processColor, StyleSheet, View } from 'react-native';
-
+import React, {Component, createRef} from 'react';
+import {StyleSheet, View} from 'react-native';
 import NativeLinearGradient, { type Props } from './src';
 
 const convertPoint = (name, point) => {
@@ -85,7 +84,7 @@ export default class LinearGradient extends Component<Props> {
       <View ref={this.gradientRef} {...otherProps} style={style}>
         <NativeLinearGradient
           style={{position: 'absolute', top: 0, left: 0, bottom: 0, right: 0}}
-          colors={colors.map(processColor)}
+          colors={colors}
           startPoint={convertPoint('start', start)}
           endPoint={convertPoint('end', end)}
           locations={locations ? locations.slice(0, colors.length) : null}

--- a/index.ios.js
+++ b/index.ios.js
@@ -2,9 +2,7 @@
  * @providesModule LinearGradient
  * @flow
  */
-import React, { Component, createRef } from 'react';
-import { processColor } from 'react-native';
-
+import React, {Component, createRef} from 'react';
 import NativeLinearGradient, { type Props } from './src';
 
 const convertPoint = (name, point) => {
@@ -56,7 +54,7 @@ export default class LinearGradient extends Component<Props> {
         {...otherProps}
         startPoint={convertPoint('start', start)}
         endPoint={convertPoint('end', end)}
-        colors={colors.map(processColor)}
+        colors={colors}
         locations={locations ? locations.slice(0, colors.length) : null}
         useAngle={useAngle}
         angleCenter={convertPoint('angleCenter', angleCenter)}

--- a/ios/RNLinearGradient.mm
+++ b/ios/RNLinearGradient.mm
@@ -8,7 +8,6 @@
 #import <react/renderer/components/RNLinearGradientSpec/Props.h>
 #import <react/renderer/components/RNLinearGradientSpec/RCTComponentViewHelpers.h>
 
-#import "RCTFabricComponentsPlugins.h"
 #endif
 
 #import <React/RCTConvert.h>

--- a/package.json
+++ b/package.json
@@ -51,11 +51,6 @@
       "componentProvider": {
         "RNLinearGradient": "RNLinearGradient"
       }
-    },
-    "android": {
-      "componentProvider": {
-        "RNLinearGradient": "RNLinearGradient"
-      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,17 @@
   },
   "codegenConfig": {
     "name": "RNLinearGradientSpec",
-    "type": "components",
-    "jsSrcsDir": "src"
+    "type": "all",
+    "jsSrcsDir": "src",
+    "ios": {
+      "componentProvider": {
+        "RNLinearGradient": "RNLinearGradient"
+      }
+    },
+    "android": {
+      "componentProvider": {
+        "RNLinearGradient": "RNLinearGradient"
+      }
+    }
   }
 }


### PR DESCRIPTION
The native view works in interop mode, so the style of the native view is incorrect.
I have fixed the configuration of codegen support, which allows the view to work on new architectures with Fabric. 