### PR TITLE
Make start / end point defaults in iOS native code match codegen's generated defaults

### DIFF
--- a/ios/RNLinearGradientLayer.m
+++ b/ios/RNLinearGradientLayer.m
@@ -11,8 +11,8 @@
     if (self) {
         self.needsDisplayOnBoundsChange = YES;
         self.masksToBounds = YES;
-        _startPoint = CGPointMake(0.5, 0.0);
-        _endPoint = CGPointMake(0.5, 1.0);
+        _startPoint = CGPointMake(0.0, 0.0);
+        _endPoint = CGPointMake(0.0, 0.0);
         _angleCenter = CGPointMake(0.5, 0.5);
         _angle = 45.0;
     }


### PR DESCRIPTION
This commit fixes a bug (in the v3 beta) where a linear gradient can appear rotated / incorrect on initial load if the `start` or `end` properties are set to `{x: 0, y: 0}` in JSX, i.e. like this:

```
<LinearGradient
   colors={[styles.red, styles.yellow]}
   style={styles.gradient}
   start={{ x: 0, y: 0 }}
   end={{ x: 0, y: 1 }}
/>
```

The issue is this: when codegen runs on the `react-native-linear-gradient` package, it looks at the [JS spec file](https://github.com/react-native-linear-gradient/react-native-linear-gradient/blob/master/src/RNLinearGradientNativeComponent.ts) to generate the c++ interface. In here, `startPoint` and `endPoint` are initialized as a PointValue with `{x: 0, y: 0}`.

However, in the [iOS native component](https://github.com/react-native-linear-gradient/react-native-linear-gradient/blob/master/ios/RNLinearGradientLayer.m) that implements the codegen interface, the start and endpoints are initialized to different values: {x:0.5, y:0.0} and {x:0.5, y:1.0}, respectively.

What ended up happening here is a mismatch between what react native thought the values were and what they actually were set to in the native layer.

When our JSX creates a linear gradient component with an intentional value of 0,0 for either point, as we do in the above example...

That start value of `x: 0, y: 0` matches what react native thinks the value should be. So under the hood, that property set is a no-op, because `updateProps:` sees the props didn't change.

HOWEVER! The true value of the native component was initialized to `{x:0.5, y:0.0}`. Meaning that the linear gradient will render as `{x:0.5, y:0.0}` even though we expect it to be 0,0. This causes the linear gradient to appear rotated from what we expect.

The fix is to ensure that the native default props match what codegen (and the RN layer) expects. This will allow any changes from the default to apply properly.

If start or end are omitted, we still set the old defaults here: https://github.com/react-native-linear-gradient/react-native-linear-gradient/blob/c98d6313b25aa1dc1bee897054d9f6388746044a/src/LinearGradient.tsx#L110.