### PR TITLE
[RN 0.87] Add namespace for LinearGradient library

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,6 +20,7 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
+    namespace 'com.BV.LinearGradient'
     compileSdkVersion safeExtGet('compileSdkVersion', 31).toInteger()
     defaultConfig {
         minSdkVersion safeExtGet('minSdkVersion', 21)


### PR DESCRIPTION
This is needed for this library to work correctly with React Native 0.87.

I see that the latest tag on NPM is still on the 2.8 so I'm proposing this hotfix on the 2.8 branch.

An alternative would be to release 3.0.0 stable and drop this PR as it contains this fix already.